### PR TITLE
Optimizes GitLabCI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,12 +78,10 @@ build coach:
   services:
     - docker:dind
   script:
-    # - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD # Logs in to dockerhub
-    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY 
+    - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD # Logs in to dockerhub
     - docker pull $COACH_TEMP_IMAGE
     - docker tag $COACH_TEMP_IMAGE $COACH_IMAGE:latest
-    # - docker push $COACH_IMAGE:latest
-    - docker push $CI_REGISTRY_IMAGE/$COACH_IMAGE:latest
+    - docker push $COACH_IMAGE:latest
   only:
     - master
     - gitlabci
@@ -101,12 +99,10 @@ build bot:
   services:
     - docker:dind
   script:
-    # - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD # Logs in to dockerhub
-    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+    - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD # Logs in to dockerhub
     - docker pull $BOT_TEMP_IMAGE
     - docker tag $BOT_TEMP_IMAGE $BOT_IMAGE:latest
-    # - docker push $BOT_IMAGE:latest
-    - docker push $CI_REGISTRY_IMAGE/$BOT_IMAGE:latest
+    - docker push $BOT_IMAGE:latest
   only:
     - master
     - gitlabci

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,6 @@ build requirements:
   only:
     refs:
       - master
-      - gitlabci
     changes:
       - ./docker/bot/requirements.txt
   environment: homolog
@@ -84,7 +83,6 @@ build coach:
     - docker push $COACH_IMAGE:latest
   only:
     - master
-    - gitlabci
   environment: homolog
 
 
@@ -105,5 +103,4 @@ build bot:
     - docker push $BOT_IMAGE:latest
   only:
     - master
-    - gitlabci
   environment: homolog

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,8 @@ image: python:3.6-slim
 variables:
   BOT_IMAGE: $DOCKERHUB_USER/bot
   COACH_IMAGE: $DOCKERHUB_USER/coach
+  COACH_TEMP_IMAGE: $CI_REGISTRY_IMAGE/ci/coach:$CI_COMMIT_SHORT_SHA
+  BOT_TEMP_IMAGE: $CI_REGISTRY_IMAGE/ci/bot:$CI_COMMIT_SHORT_SHA
 
 stages:
   - test style
@@ -35,9 +37,12 @@ test stories:
   services:
     - docker:dind
   script:
-    - docker build -f docker/coach.Dockerfile -t $COACH_IMAGE:latest .
-    - docker build -f docker/bot.Dockerfile -t $BOT_IMAGE:latest .
-    - docker run --rm $BOT_IMAGE:latest make test-stories
+    - docker build -f docker/coach.Dockerfile -t $COACH_TEMP_IMAGE .
+    - docker build -f docker/bot.Dockerfile -t $BOT_TEMP_IMAGE .
+    - docker run --rm $BOT_TEMP_IMAGE make test-stories
+    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY # logs in to gitlab registry
+    - docker push $COACH_TEMP_IMAGE
+    - docker push $BOT_TEMP_IMAGE
 
 
 #############################################################
@@ -57,6 +62,7 @@ build requirements:
   only:
     refs:
       - master
+      - gitlabci
     changes:
       - ./docker/bot/requirements.txt
   environment: homolog
@@ -73,11 +79,15 @@ build coach:
   services:
     - docker:dind
   script:
-    - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    - docker build -f docker/coach.Dockerfile -t $COACH_IMAGE:latest .
-    - docker push $COACH_IMAGE:latest
+    # - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD # Logs in to dockerhub
+    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY 
+    - docker pull $COACH_TEMP_IMAGE
+    - docker tag $COACH_TEMP_IMAGE $COACH_IMAGE:latest
+    # - docker push $COACH_IMAGE:latest
+    - docker push $CI_REGISTRY_IMAGE/$COACH_IMAGE:latest
   only:
     - master
+    - gitlabci
   environment: homolog
 
 
@@ -92,9 +102,13 @@ build bot:
   services:
     - docker:dind
   script:
-    - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    - docker build -f docker/bot.Dockerfile -t $BOT_IMAGE:latest .
-    - docker push $BOT_IMAGE:latest
+    # - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD # Logs in to dockerhub
+    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+    - docker pull $BOT_TEMP_IMAGE
+    - docker tag $BOT_TEMP_IMAGE $BOT_IMAGE:latest
+    # - docker push $BOT_IMAGE:latest
+    - docker push $CI_REGISTRY_IMAGE/$BOT_IMAGE:latest
   only:
     - master
+    - gitlabci
   environment: homolog

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,8 @@ variables:
 
 stages:
   - test style
-  - test stories
   - build requirements
+  - test stories
   - build coach
   - build
 
@@ -57,8 +57,7 @@ build requirements:
     - docker:dind
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    - cd ./docker/bot
-    - ./build-base.sh publish
+    - ./docker/build-base.sh
   only:
     refs:
       - master


### PR DESCRIPTION
Now, there bot training occurs only before testing. Instead of rebuilding the images, the subsequent stages pull, from GitLab Registry, the previously built images, retag and upload them to Dockerhub.