### PR TITLE
Changes docker "latest" tags to "tais" tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,8 +79,8 @@ build coach:
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD # Logs in to dockerhub
     - docker pull $COACH_TEMP_IMAGE
-    - docker tag $COACH_TEMP_IMAGE $COACH_IMAGE:latest
-    - docker push $COACH_IMAGE:latest
+    - docker tag $COACH_TEMP_IMAGE $COACH_IMAGE:bottis
+    - docker push $COACH_IMAGE:bottis
   only:
     - master
   environment: homolog
@@ -99,8 +99,8 @@ build bot:
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD # Logs in to dockerhub
     - docker pull $BOT_TEMP_IMAGE
-    - docker tag $BOT_TEMP_IMAGE $BOT_IMAGE:latest
-    - docker push $BOT_IMAGE:latest
+    - docker tag $BOT_TEMP_IMAGE $BOT_IMAGE:bottis
+    - docker push $BOT_IMAGE:bottis
   only:
     - master
   environment: homolog

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   # =============================== Coach =================================  
   coach:
     container_name: coach
-    image: botcoach:latest
+    image: lappis/coach:bottis
     volumes:
       - notebook_models:/notebook_models
     command: sh -c "cp -r /src_models/* /notebook_models"


### PR DESCRIPTION
Since there are 3 different bot projects inside lappis org, and all of them push images to dockerhub, to avoid image conflicts, there should be a specific tag for each project. This PR changes all the "latest" tags to "bottis".